### PR TITLE
Fix package discovery error in setuptools configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ dependencies = [
 "Homepage" = "https://github.com/mjendrusch/flexcraft"
 "Bug reportes" = "https://github.com/mjendrusch/flexcraft/issues"
 "Source" = "https://github.com/mjendrusch/flexcraft/"
+
+[tool.setuptools.packages.find]
+include = ["flexcraft*"]
+exclude = ["data*"]


### PR DESCRIPTION
## Error
```
error: Multiple top-level packages discovered in a flat-layout: ['data', 'flexcraft'].
To avoid accidental inclusion of unwanted files or directories, setuptools will not proceed with this build.
```

## Solution
Added explicit package discovery configuration to `pyproject.toml`:
```toml
[tool.setuptools.packages.find]
include = ["flexcraft*"]
exclude = ["data*"]
```

This tells setuptools to:
- Include only packages starting with "flexcraft" 
- Explicitly exclude the "data" directory from being treated as a package

- [x] Installation via `pip install .` now works successfully
- [x] Installation via `pip install git+https://github.com/mjendrusch/flexcraft.git` now works

