### PR TITLE
Caching boltz features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ __pycache__/
 ._.DS_Store
 ._*
 flexcraft_params/
+data/**/*
+params/**/*
+logs/**/*
+**/*.log
+sandbox.ipynb
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__/
 ._*
 flexcraft_params/
 data/**/*
-params/**/*
+**/params/**/*
 logs/**/*
 **/*.log
 sandbox.ipynb

--- a/flexcraft/structure/boltz/_data.py
+++ b/flexcraft/structure/boltz/_data.py
@@ -57,7 +57,7 @@ def _prefix():
 sequences:"""
 
 def _make_features(chains: list, templates: list, constraints: list,
-                   cache="./params/boltz/"):
+                   cache="./params/boltz/", out_dir=None):
     chain_order = [c for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
     yaml = "\n".join(
         [_prefix()]
@@ -73,17 +73,20 @@ def _make_features(chains: list, templates: list, constraints: list,
     has_constraint, constraint_yaml = build_constraint_yaml(constraints)
     if has_constraint:
         yaml += constraint_yaml
-    features, writer_spec = _features_from_yaml(yaml, cache=cache)
+    features, writer_spec = _features_from_yaml(yaml, cache=cache, out_dir=out_dir)
     if has_template:
         assert np.sum(features["template_mask"]) > 0
     return features, writer_spec
 
 class JoltzSpec:
-    def __init__(self, *chains, templates=None, constraints=None):
+    def __init__(self, *chains, templates=None, constraints=None, out_dir=None):
         self.chains = list(chains)
         self.templates = templates or list()
         self.constraints = constraints or list()
         self.temporaries = list()
+        # directory storing boltz results for recomputing,
+        # if None, temp dir will be created
+        self.out_dir = out_dir
 
     def add_chain(self, *chains):
         _chains = []
@@ -199,7 +202,7 @@ class JoltzSpec:
 
     def to_features(self, pad=True, cache="./params/boltz/") -> dict:
         features, writer_spec = _make_features(
-            self.chains, self.templates, self.constraints, cache=cache)
+            self.chains, self.templates, self.constraints, cache=cache, out_dir=self.out_dir)
         if pad:
             features = pad_boltz_atom_features_for_compilation(features)
         writer_features = {
@@ -210,6 +213,10 @@ class JoltzSpec:
         writer_spec["features_dict"] = writer_features
         features = jax.tree.map(jnp.array, features)
         return features, writer_spec
+
+    def set_out_dir(self, out_dir):
+        self.out_dir = Path(out_dir)
+        return self
 
     def to_input(self, pad=True, cache="./params/boltz/") -> "JoltzInput":
         features, writer_spec = self.to_features(pad=pad, cache=cache)
@@ -389,13 +396,22 @@ constraints:"""
 def _features_from_yaml(
     input_yaml_str: str,
     cache=Path("./params/boltz/").expanduser(),
+    out_dir=None,
 ) -> PyTree:
     if not isinstance(cache, Path):
         cache = Path(cache).expanduser()
-    out_dir_handle = (
-        TemporaryDirectory()
-    )  # this is sketchy -- we have to remember not to let this get garbage collected
-    out_dir = Path(out_dir_handle.name)
+    if out_dir is None:
+        out_dir_handle = (
+            TemporaryDirectory()
+        )  # this is sketchy -- we have to remember not to let this get garbage collected
+        out_dir = Path(out_dir_handle.name)
+    else:
+        class _wrap_path:
+            def __init__(self, path):
+                path = Path(path)
+                self.name = path.__str__()
+        out_dir_handle = _wrap_path(path=out_dir)
+
     # dump the yaml to a file
     input_data_path = out_dir / "input.yaml"
     input_data_path.write_text(input_yaml_str)

--- a/flexcraft/structure/boltz/_data.py
+++ b/flexcraft/structure/boltz/_data.py
@@ -139,7 +139,8 @@ class JoltzSpec:
         template_info = dict(template=path_or_object, template_chains=to_chains)
         if isinstance(path_or_object, str):
             if path_or_object.endswith((".pdb", ".pdb1")):
-                template_info["pdb"] = path_or_object
+                path = self.prep_pdb(path_or_object)
+                template_info["cif"] = path
             elif path_or_object.endswith(".cif"):
                 template_info["cif"] = path_or_object
             else:
@@ -147,13 +148,23 @@ class JoltzSpec:
                                           f"Has to be either '.pdb' or '.cif'.")
         elif isinstance(path_or_object, DesignData):
             tmpfile = PDBFile(data = path_or_object, temporary = True)
+            tmpfile = self.prep_pdb(tmpfile.path)
             self.temporaries.append(tmpfile)
-            template_info["pdb"] = tmpfile.path
+            template_info["cif"] = tmpfile
         else:
             raise NotImplementedError(
                 "Input template has to be a path to a '.pdb' or '.cif' file.")
         self.templates.append(template_info)
         return self
+
+    def prep_pdb(self, path):
+        import os
+        from time import sleep
+        os.system(f"maxit -input {path} -output {Path(path).with_suffix('.cif')} -o 1")
+        while not Path(path).with_suffix('.cif').exists():
+            sleep(2)
+        return str(Path(path).with_suffix('.cif'))
+
 
     def add_msa(self, to_chains=None):
         if to_chains is None:

--- a/flexcraft/structure/boltz/_model.py
+++ b/flexcraft/structure/boltz/_model.py
@@ -64,6 +64,7 @@ def load_boltz2(model="boltz2_conf.ckpt", cache=Path("./params/boltz/")):
             )
         ),
         pairformer_args=asdict(boltz_main.PairformerArgsV2()),
+        weights_only=False
     ).eval()
 
     model = joltz.from_torch(torch_model)

--- a/notebooks/boltzCaching/devel.ipynb
+++ b/notebooks/boltzCaching/devel.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c35cc114",
+   "metadata": {},
+   "source": [
+    "### For testing the caching directory (\"out_dir\") of the boltz spec\n",
+    "-> Run with GPU allocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c04ada8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flexcraft.structure.boltz import *\n",
+    "from flexcraft.data.data import DesignData\n",
+    "from flexcraft.files import PDBFile\n",
+    "from flexcraft.sequence.aa_codes import *\n",
+    "from flexcraft.utils.rng import Keygen\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb24fd50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_dir = Path(\"/home/hgf_dkfz/hgf_dsb0249/workspaces/haicwork/hgf_dsb0249-BinderDesign/flexcraft/data/boltzCaching/test_dir\")\n",
+    "test_file = test_dir/\"test_template_clean.pdb\"\n",
+    "\n",
+    "test_structure = PDBFile(path=test_file).to_data()\n",
+    "test_seq = test_structure.to_sequence_string()\n",
+    "template_file = test_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53541d7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "            \"docking\":False,\n",
+    "            \"redocking\":False,\n",
+    "            \"parameter_path\":Path(\"./params/boltz\"),\n",
+    "            \"model_name\":\"boltz2_conf\",\n",
+    "            \"num_recycle\":2,\n",
+    "            \"num_samples\":1,\n",
+    "            \"num_sampling_steps\":25,\n",
+    "            \"deterministic\":False,\n",
+    "            \"predictor\":None,\n",
+    "            \"msa\":True,\n",
+    "            }\n",
+    "boltz = Joltz2(model=config[\"model_name\"]+\".ckpt\", cache=config[\"parameter_path\"])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19d61b91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "boltz_evaluator, config[\"params\"] = boltz.evaluator(\n",
+    "    num_recycle=config[\"num_recycle\"],\n",
+    "    num_sampling_steps=config[\"num_sampling_steps\"],\n",
+    "    deterministic=config[\"deterministic\"]\n",
+    ")\n",
+    "def _wrap_eval(key, params, joltz_input, num_samples=config[\"num_samples\"]):\n",
+    "    return boltz_evaluator(params\n",
+    "    ).predict(key, joltz_input, num_samples=num_samples,)\n",
+    "predictor = jax.jit(_wrap_eval, static_argnames=\"num_samples\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b02cc69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key = Keygen(11)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d52969a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "caching_dir = test_dir/\"boltz_cache\"\n",
+    "caching_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "joltz_spec = JoltzSpec(out_dir=caching_dir).add_protein(test_seq, use_msa=config[\"msa\"])\n",
+    "joltz_spec = joltz_spec.add_template(template_file.__str__())\n",
+    "\n",
+    "boltz_input, boltz_writer = joltz_spec.to_input(pad=True, cache=config[\"parameter_path\"])\n",
+    "boltz_result = predictor(\n",
+    "    key(),\n",
+    "    config[\"params\"],\n",
+    "    boltz_input,\n",
+    "    num_samples=config[\"num_samples\"]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d526cbfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if msa is not recomputed and \"All inputs are already processed.\" gets printed, we can assume the cache is working correctly\n",
+    "joltz_spec = JoltzSpec(out_dir=caching_dir).add_protein(test_seq, use_msa=config[\"msa\"])\n",
+    "joltz_spec = joltz_spec.add_template(template_file.__str__())\n",
+    "\n",
+    "boltz_input, boltz_writer = joltz_spec.to_input(pad=True, cache=config[\"parameter_path\"])\n",
+    "boltz_result_cached = predictor(\n",
+    "    key(),\n",
+    "    config[\"params\"],\n",
+    "    boltz_input,\n",
+    "    num_samples=config[\"num_samples\"]\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I have implemented a small feature to optionally specify the directory boltz features get saved in. This allows boltz to reuse template and msa informations.

The generated cache dir looks like this:
<img width="431" height="620" alt="image" src="https://github.com/user-attachments/assets/8d547bbb-61ea-4e31-8f25-2599565eabab" />

This is a feature that shouldn't change any existing workflows but adds the option to reduce computation considerably.

Note: This is still preliminary and feedback would be much appreciated!